### PR TITLE
Fixing: Garbled characters for Windows

### DIFF
--- a/mdfy/mdfy.py
+++ b/mdfy/mdfy.py
@@ -35,7 +35,7 @@ class Mdfier:
         > This is a quote.
     """
 
-    def __init__(self, filepath: Union[str, Path]) -> None:
+    def __init__(self, filepath: Union[str, Path], encoding: str = "utf-8") -> None:
         """Initializes an instance of the Mdfier class to write Markdown content to a file.
 
         Args:
@@ -45,6 +45,7 @@ class Mdfier:
         self.filepath = Path(filepath)
         self.filepath.parent.mkdir(parents=True, exist_ok=True)
         self.file_object: Optional[TextIOWrapper] = None
+        self._encoding = encoding
 
     def __enter__(self) -> "Mdfier":
         """Returns the Mdfier instance.
@@ -53,7 +54,7 @@ class Mdfier:
             Mdfier: The Mdfier instance.
         """
 
-        self.file_object = self.filepath.open("w")
+        self.file_object = self.filepath.open("w", encoding=self._encoding)
         return self
 
     def __exit__(
@@ -94,6 +95,6 @@ class Mdfier:
             contents = [contents]
         markdown = self.stringify(contents)
         if self.file_object is None:
-            self.filepath.write_text(markdown + "\n")
+            self.filepath.write_text(markdown + "\n", encoding=self._encoding)
         else:
             self.file_object.write(markdown + "\n")

--- a/tests/mdfy_test.py
+++ b/tests/mdfy_test.py
@@ -1,37 +1,40 @@
 import tempfile
+from pathlib import Path
 
 from mdfy import Mdfier, MdHeader, MdText
 
 
 def test_mdfy_write():
-    with tempfile.NamedTemporaryFile("w+", delete=True) as tmp:
+    with tempfile.TemporaryDirectory() as tmp_dir:
         contents = [
             MdHeader("Hello, MDFY!"),
             MdText("[Life:bold] is [like:italic] a bicycle."),
         ]
-        Mdfier(tmp.name).write(contents)
+        tmp_output_path = Path(tmp_dir, "output.md")
+        Mdfier(tmp_output_path).write(contents)
 
-        tmp.seek(0)
-        lines = tmp.readlines()
+        with tmp_output_path.open() as f:
+            lines = f.readlines()
 
-        assert lines[0] == "# Hello, MDFY!\n"
-        assert lines[1] == "**Life** is *like* a bicycle.\n"
+            assert lines[0] == "# Hello, MDFY!\n"
+            assert lines[1] == "**Life** is *like* a bicycle.\n"
 
 
 def test_mdfy_write_with_statement():
-    with tempfile.NamedTemporaryFile("w+", delete=True) as tmp:
+    with tempfile.TemporaryDirectory() as tmp_dir:
         contents = [
             MdHeader("Hello, MDFY!"),
             MdText("[Life:bold] is [like:italic] a bicycle."),
         ]
-        mdier = Mdfier(tmp.name)
+        tmp_output_path = Path(tmp_dir, "output.md")
+        mdier = Mdfier(tmp_output_path)
         with mdier as mdfier:
             for content in contents:
                 mdfier.write(content)
 
-        tmp.seek(0)
-        lines = tmp.readlines()
+        with tmp_output_path.open() as f:
+            lines = f.readlines()
 
-        assert lines[0] == "# Hello, MDFY!\n"
-        assert lines[1] == "**Life** is *like* a bicycle.\n"
-        assert mdier.file_object.closed
+            assert lines[0] == "# Hello, MDFY!\n"
+            assert lines[1] == "**Life** is *like* a bicycle.\n"
+            assert mdier.file_object.closed

--- a/tests/mdfy_test.py
+++ b/tests/mdfy_test.py
@@ -38,3 +38,21 @@ def test_mdfy_write_with_statement():
             assert lines[0] == "# Hello, MDFY!\n"
             assert lines[1] == "**Life** is *like* a bicycle.\n"
             assert mdier.file_object.closed
+
+
+def test_mdfy_write_in_utf8():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        contents = [
+            MdHeader("こんにちは")
+        ]
+        tmp_output_path = Path(tmp_dir, "output.md")
+        mdier = Mdfier(tmp_output_path)
+        with mdier as mdfier:
+            for content in contents:
+                mdfier.write(content)
+
+        with tmp_output_path.open(encoding="utf-8") as f:
+            lines = f.readlines()
+
+            assert lines[0] == "# こんにちは\n"
+            assert mdier.file_object.closed


### PR DESCRIPTION
Issue: https://github.com/argonism/mdfy/issues/4

Fixing garbled text issue for windows.

Explicity specify encoding (default utf-8) when opening file or writing texts.