### PR TITLE
Add list flatten feature for writing content from mdfier

### DIFF
--- a/mdfy/__init__.py
+++ b/mdfy/__init__.py
@@ -10,7 +10,7 @@ from .elements import (
     MdTable,
     MdText,
 )
-from .mdfy import Mdfier
+from .mdfy import Mdfier, ContentType, ContentElementType
 
 __all__ = [
     "MdCode",
@@ -24,4 +24,6 @@ __all__ = [
     "MdTable",
     "MdText",
     "Mdfier",
+    "ContentType",
+    "ContentElementType",
 ]

--- a/mdfy/mdfy.py
+++ b/mdfy/mdfy.py
@@ -6,12 +6,6 @@ from typing import List, Optional, Type, Union
 from .elements import MdElement
 
 
-def write(content: str, filepath: str) -> None:
-    with open(filepath, "w") as file:
-        for item in content:
-            file.write(str(item) + "\n")
-
-
 class Mdfier:
     """Writes Markdown content to a file.
 
@@ -81,6 +75,8 @@ class Mdfier:
         Args:
             content (Union[str, MdElement]): The Markdown content to convert to a string.
         """
+
+
 
         return "\n".join([str(item) for item in contents])
 

--- a/mdfy/mdfy.py
+++ b/mdfy/mdfy.py
@@ -1,8 +1,7 @@
 from io import TextIOWrapper
 from pathlib import Path
 from types import TracebackType
-from typing import List, Optional, Type, Union
-from collections.abc import Iterable
+from typing import List, Optional, Type, Union, Iterable
 
 from .elements import MdElement
 

--- a/mdfy/mdfy.py
+++ b/mdfy/mdfy.py
@@ -7,9 +7,9 @@ from collections.abc import Iterable
 from .elements import MdElement
 
 
-ContentElementType = str | MdElement
-_ContentType = ContentElementType | Iterable[ContentElementType]
-ContentType = _ContentType | Iterable[_ContentType]
+ContentElementType = Union[str, MdElement]
+_ContentType = Union[ContentElementType, Iterable[ContentElementType]]
+ContentType = Union[_ContentType, Iterable[_ContentType]]
 
 
 def _flattern(content: ContentType) -> List[ContentElementType]:

--- a/tests/mdfy_test.py
+++ b/tests/mdfy_test.py
@@ -1,7 +1,7 @@
 import tempfile
 from pathlib import Path
 
-from mdfy import Mdfier, MdHeader, MdText
+from mdfy import Mdfier, MdHeader, MdText, MdLink, MdElement
 
 
 def test_mdfy_write() -> None:
@@ -13,7 +13,7 @@ def test_mdfy_write() -> None:
         tmp_output_path = Path(tmp_dir, "output.md")
         Mdfier(tmp_output_path).write(contents)
 
-        with tmp_output_path.open() as f:
+        with tmp_output_path.open(encoding="utf-8") as f:
             lines = f.readlines()
 
             assert lines[0] == "# Hello, MDFY!\n"
@@ -32,7 +32,7 @@ def test_mdfy_write_with_statement() -> None:
             for content in contents:
                 mdfier.write(content)
 
-        with tmp_output_path.open() as f:
+        with tmp_output_path.open(encoding="utf-8") as f:
             lines = f.readlines()
 
             assert lines[0] == "# Hello, MDFY!\n"
@@ -55,4 +55,28 @@ def test_mdfy_write_in_utf8() -> None:
             lines = f.readlines()
 
             assert lines[0] == "# こんにちは\n"
-            assert mdier.file_object.closed
+            assert mdfier.file_object and mdfier.file_object.closed
+
+
+def test_mdfy_nested_contents() -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        contents: list[MdElement | list[MdElement]]  = [
+            MdHeader("Hello, MDFY!"),
+            [
+                MdText("This is a nested content."),
+                MdText("This is another nested content."),
+                (
+                    MdLink("url", "Click me!")
+                )
+            ],
+        ]
+        tmp_output_path = Path(tmp_dir, "output.md")
+        Mdfier(tmp_output_path).write(contents)
+
+        with tmp_output_path.open(encoding="utf-8") as f:
+            lines = f.readlines()
+
+            assert lines[0] == "# Hello, MDFY!\n"
+            assert lines[1] == "This is a nested content.\n"
+            assert lines[2] == "This is another nested content.\n"
+            assert lines[3] == "[Click me!](url)\n"

--- a/tests/mdfy_test.py
+++ b/tests/mdfy_test.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from mdfy import Mdfier, MdHeader, MdText
 
 
-def test_mdfy_write():
+def test_mdfy_write() -> None:
     with tempfile.TemporaryDirectory() as tmp_dir:
         contents = [
             MdHeader("Hello, MDFY!"),
@@ -20,15 +20,15 @@ def test_mdfy_write():
             assert lines[1] == "**Life** is *like* a bicycle.\n"
 
 
-def test_mdfy_write_with_statement():
+def test_mdfy_write_with_statement() -> None:
     with tempfile.TemporaryDirectory() as tmp_dir:
         contents = [
             MdHeader("Hello, MDFY!"),
             MdText("[Life:bold] is [like:italic] a bicycle."),
         ]
         tmp_output_path = Path(tmp_dir, "output.md")
-        mdier = Mdfier(tmp_output_path)
-        with mdier as mdfier:
+        mdfier = Mdfier(tmp_output_path)
+        with mdfier as mdfier:
             for content in contents:
                 mdfier.write(content)
 
@@ -37,10 +37,10 @@ def test_mdfy_write_with_statement():
 
             assert lines[0] == "# Hello, MDFY!\n"
             assert lines[1] == "**Life** is *like* a bicycle.\n"
-            assert mdier.file_object.closed
+            assert mdfier.file_object and mdfier.file_object.closed
 
 
-def test_mdfy_write_in_utf8():
+def test_mdfy_write_in_utf8() -> None:
     with tempfile.TemporaryDirectory() as tmp_dir:
         contents = [
             MdHeader("こんにちは")

--- a/tests/mdfy_test.py
+++ b/tests/mdfy_test.py
@@ -42,9 +42,7 @@ def test_mdfy_write_with_statement() -> None:
 
 def test_mdfy_write_in_utf8() -> None:
     with tempfile.TemporaryDirectory() as tmp_dir:
-        contents = [
-            MdHeader("こんにちは")
-        ]
+        contents = [MdHeader("こんにちは")]
         tmp_output_path = Path(tmp_dir, "output.md")
         mdier = Mdfier(tmp_output_path)
         with mdier as mdfier:
@@ -60,14 +58,12 @@ def test_mdfy_write_in_utf8() -> None:
 
 def test_mdfy_nested_contents() -> None:
     with tempfile.TemporaryDirectory() as tmp_dir:
-        contents: list[MdElement | list[MdElement]]  = [
+        contents: list[MdElement | list[MdElement]] = [
             MdHeader("Hello, MDFY!"),
             [
                 MdText("This is a nested content."),
                 MdText("This is another nested content."),
-                (
-                    MdLink("url", "Click me!")
-                )
+                (MdLink("url", "Click me!")),
             ],
         ]
         tmp_output_path = Path(tmp_dir, "output.md")


### PR DESCRIPTION
With this feature, we can directory pass nested const to `mdfier.write` as this:
```python
from mdfy import Mdfier, MdHeader, MdText, MdLink, MdElement

contents: list[MdElement | list[MdElement]]  = [
    MdHeader("Hello, MDFY!"),
    [
        MdText("This is a nested content."),
        MdText("This is another nested content."),
        (
            MdLink("url", "Click me!")
        )
    ],
]
Mdfier(tmp_output_path).write(contents)
```

With this code, following markdown will be generated:

``` markdown
# Hello, MDFY!
This is a nested content.
This is another nested content.
[Click me!](url)
```